### PR TITLE
We aren't using this anywhere

### DIFF
--- a/snapshots.proto
+++ b/snapshots.proto
@@ -58,8 +58,6 @@ message SnapshotMetadata {
     bytes UUID = 1;
     // timestamp when this snapshot was created
     google.protobuf.Timestamp created = 2;
-    // the number of items in this snapshot
-    uint32 size = 3;
 }
 
 ////////////////////////////


### PR DESCRIPTION
Also the logic doesn't make whole lot of sense. Surely if we're going to count the size it should be in bytes? If we did actually want the number if items surely we'd also want the number of other things like queries.

Since it's not used I figure it's best to remove for noe