### PR TITLE
Change-lifecycle

### DIFF
--- a/changes.proto
+++ b/changes.proto
@@ -203,8 +203,15 @@ message ChangeProperties {
   // Example: susan@contoso.com, jimmy@contoso.com
   string ccEmails = 6;
 
-  // UUID of a bookmark for the item queries of the items affected by this change, as selected by the customer when defining the change.
+  // UUID of a bookmark for the item queries of the items *directly* affected by
+  // this change. This might be parsed from a terrform plam, added from the API,
+  // parsed from a freeform ticket description etc.
   bytes affectedItemsBookmarkUUID = 7;
+
+  // UUID of a bookmark for the item queries of the items *indirectly* affected
+  // by this change i.e. the blast radius. This will be determined
+  // automatically, but can refined by the user.
+  bytes blastRadiusBookmarkUUID = 11;
 
   // UUID of the whole-system snapshot created before the change has started.
   bytes systemBeforeSnapshotUUID = 8;

--- a/changes.proto
+++ b/changes.proto
@@ -296,7 +296,13 @@ message DeleteChangeRequest {
 message DeleteChangeResponse {}
 
 message CalculateBlastRadiusRequest {
+  // ID of the change to calculate the blast radius for.
   bytes changeUUID = 1;
+  // If true, the blast radius will be calculated again, even if it was already.
+  // Otherwise if the blast radius has already been calculated (i.e. the status
+  // is `DEFINING` and `blastRadiusBookmarkUUID` is set) an error will be
+  // returned.
+  bool force = 2;
 }
 
 message CalculateBlastRadiusResponse {

--- a/changes.proto
+++ b/changes.proto
@@ -295,7 +295,9 @@ message DeleteChangeRequest {
 
 message DeleteChangeResponse {}
 
-message CalculateBlastRadiusRequest {}
+message CalculateBlastRadiusRequest {
+  bytes changeUUID = 1;
+}
 
 message CalculateBlastRadiusResponse {
   enum State {
@@ -315,7 +317,9 @@ message CalculateBlastRadiusResponse {
   uint32 NumEdges = 3;
 }
 
-message StartChangeRequest {}
+message StartChangeRequest {
+  bytes changeUUID = 1;
+}
 
 message StartChangeResponse {
   enum State {

--- a/changes.proto
+++ b/changes.proto
@@ -67,7 +67,7 @@ service ChangesService {
   // Executing this RPC take a snapshot of the current blast radius and store it
   // in `systemBeforeSnapshotUUID` and then advance the status to
   // `STATUS_HAPPENING`. It can only be called once per change.
-  rpc StartChnage(StartChangeRequest) returns (stream StartChangeResponse);
+  rpc StartChange(StartChangeRequest) returns (stream StartChangeResponse);
 
   // Takes the "after" snapshot, stores it in `systemAfterSnapshotUUID` and
   // advances the change status to `STATUS_DONE`

--- a/changes.proto
+++ b/changes.proto
@@ -60,8 +60,9 @@ service ChangesService {
 
   // Calculates the blast radius of a change using the
   // `affectedItemsBookmarkUUID` as the starting point. If the
-  // `affectedItemsBookmarkUUID` is blank, this will return an error. Executing
-  // this RPC will move the change to the `STATUS_DEFINING` state.
+  // `affectedItemsBookmarkUUID` is blank, this will return an error.
+  // Returns a stream of status updates. The response stream closes when all calculating has been done.
+  // Executing this RPC will move the Change to the `STATUS_DEFINING` state or return an error.
   rpc CalculateBlastRadius(CalculateBlastRadiusRequest) returns (stream CalculateBlastRadiusResponse);
 
   // Executing this RPC take a snapshot of the current blast radius and store it

--- a/changes.proto
+++ b/changes.proto
@@ -337,7 +337,9 @@ message StartChangeResponse {
   uint32 NumEdges = 3;
 }
 
-message EndChangeRequest {}
+message EndChangeRequest {
+  bytes changeUUID = 1;
+}
 
 message EndChangeResponse {
   enum State {

--- a/changes.proto
+++ b/changes.proto
@@ -48,6 +48,21 @@ service ChangesService {
   rpc UpdateChange(UpdateChangeRequest) returns (UpdateChangeResponse);
   rpc DeleteChange(DeleteChangeRequest) returns (DeleteChangeResponse);
 
+  // Calculates the blast radius of a change using the
+  // `affectedItemsBookmarkUUID` as the starting point. If the
+  // `affectedItemsBookmarkUUID` is blank, this will return an error. Executing
+  // this RPC will move the change to the `STATUS_DEFINING` state.
+  rpc CalculateBlastRadius(CalculateBlastRadiusRequest) returns (stream CalculateBlastRadiusResponse);
+
+  // Executing this RPC take a snapshot of the current blast radius and store it
+  // in `systemBeforeSnapshotUUID` and then advance the status to
+  // `STATUS_HAPPENING`. It can only be called once per change.
+  rpc StartChnage(StartChangeRequest) returns (stream StartChangeResponse);
+
+  // Takes the "after" snapshot, stores it in `systemAfterSnapshotUUID` and
+  // andvances the change status to `STATUS_DONE`
+  rpc EndChange(EndChangeRequest) returns (stream EndChangeResponse);
+
   rpc GetOnboarding(GetOnboardingRequest) returns (GetOnboardingResponse);
   rpc UpdateOnboarding(UpdateOnboardingRequest) returns (UpdateOnboardingResponse);
 
@@ -268,6 +283,63 @@ message DeleteChangeRequest {
 }
 
 message DeleteChangeResponse {}
+
+message CalculateBlastRadiusRequest {}
+
+message CalculateBlastRadiusResponse {
+  enum State {
+    // The blast radius is being calculated.
+    STATE_DISCOVERING = 0;
+    // The blast radius has been calculated and is being saved
+    STATE_SAVING = 1;
+    // Determining which apps are within the blast radius
+    STATE_FINDING_APPS = 2;
+    // Everything is complete
+    STATE_DONE = 3;
+  }
+  
+  State state = 1;
+
+  uint32 numItems = 2;
+  uint32 NumEdges = 3;
+}
+
+message StartChangeRequest {}
+
+message StartChangeResponse {
+  enum State {
+    // Snapshot is being taken
+    STATE_TAKING_SNAPSHOT = 0;
+    // Snapshot is being saved
+    STATE_SAVING_SNAPSHOT = 1;
+    // Everything is complete
+    STATE_DONE = 2;
+  }
+
+  State state = 1;
+
+  uint32 numItems = 2;
+  uint32 NumEdges = 3;
+}
+
+message EndChangeRequest {}
+
+message EndChangeResponse {
+  enum State {
+    // Snapshot is being taken
+    STATE_TAKING_SNAPSHOT = 0;
+    // Snapshot is being saved
+    STATE_SAVING_SNAPSHOT = 1;
+    // Everything is complete
+    STATE_DONE = 2;
+  }
+
+  State state = 1;
+  
+  uint32 numItems = 2;
+  uint32 NumEdges = 3;
+}
+
 
 ////////////////
 // Onboarding //

--- a/changes.proto
+++ b/changes.proto
@@ -36,16 +36,26 @@ option go_package = "github.com/overmindtech/sdp-go;sdp";
 
 // All the request/reply APIs for the Change/App iteration
 service ChangesService {
+  // Lists all apps
   rpc ListApps(ListAppsRequest) returns (ListAppsResponse);
+  // Creates a new app
   rpc CreateApp(CreateAppRequest) returns (CreateAppResponse);
+  // Gets the details of an existing app
   rpc GetApp(GetAppRequest) returns (GetAppResponse);
+  // Updates an existing app
   rpc UpdateApp(UpdateAppRequest) returns (UpdateAppResponse);
+  // Deletes an app
   rpc DeleteApp(DeleteAppRequest) returns (DeleteAppResponse);
 
+  // Lists all changes
   rpc ListChanges(ListChangesRequest) returns (ListChangesResponse);
+  // Creates a new change
   rpc CreateChange(CreateChangeRequest) returns (CreateChangeResponse);
+  // Gets the details of an existing change
   rpc GetChange(GetChangeRequest) returns (GetChangeResponse);
+  // Updates an existing change
   rpc UpdateChange(UpdateChangeRequest) returns (UpdateChangeResponse);
+  // Deletes a change
   rpc DeleteChange(DeleteChangeRequest) returns (DeleteChangeResponse);
 
   // Calculates the blast radius of a change using the
@@ -60,7 +70,7 @@ service ChangesService {
   rpc StartChnage(StartChangeRequest) returns (stream StartChangeResponse);
 
   // Takes the "after" snapshot, stores it in `systemAfterSnapshotUUID` and
-  // andvances the change status to `STATUS_DONE`
+  // advances the change status to `STATUS_DONE`
   rpc EndChange(EndChangeRequest) returns (stream EndChangeResponse);
 
   rpc GetOnboarding(GetOnboardingRequest) returns (GetOnboardingResponse);


### PR DESCRIPTION
Draft PR for change lifecycle RPCs. This will be updated with more info about having server-streaming RPCs will affect the client and server libraries

Fixes #56 

## Server-Side

On the server side the handlers are very similar, except they get passed a [`ServerStream`](https://pkg.go.dev/github.com/bufbuild/connect-go@v1.7.0#ServerStream) object rather than returning a response:

```go
func (UnimplementedChangesServiceHandler) CalculateBlastRadius(context.Context, *connect_go.Request[sdp_go.CalculateBlastRadiusRequest], *connect_go.ServerStream[sdp_go.CalculateBlastRadiusResponse]) error {
	return connect_go.NewError(connect_go.CodeUnimplemented, errors.New("changes.ChangesService.CalculateBlastRadius is not implemented"))
}

func (UnimplementedChangesServiceHandler) StartChnage(context.Context, *connect_go.Request[sdp_go.StartChangeRequest], *connect_go.ServerStream[sdp_go.StartChangeResponse]) error {
	return connect_go.NewError(connect_go.CodeUnimplemented, errors.New("changes.ChangesService.StartChnage is not implemented"))
}

func (UnimplementedChangesServiceHandler) EndChange(context.Context, *connect_go.Request[sdp_go.EndChangeRequest], *connect_go.ServerStream[sdp_go.EndChangeResponse]) error {
	return connect_go.NewError(connect_go.CodeUnimplemented, errors.New("changes.ChangesService.EndChange is not implemented"))
}
```

The handler would then call the [`Send()`](https://github.com/bufbuild/connect-go/blob/v1.7.0/handler_stream.go#L112) method to send each response, then return `nil` when done. Easy.

## Client-Side

It seems that server-streaming RPCs don't really make sense with the TanStack integration we're using (https://github.com/bufbuild/connect-query/issues/31). Instead I think we'll have to call the client directly. Thankfully the method signature that is generated is pretty nice:

```typescript
(property) calculateBlastRadius: (request: PartialMessage<CalculateBlastRadiusRequest>, options?: CallOptions | undefined) => AsyncIterable<CalculateBlastRadiusResponse>
```

Note that the result is an `AsyncIterable<CalculateBlastRadiusResponse>` which means that we need to use a `for await` loop e.g.

```typescript
const IndexPage = () => {
  const [countTo, setCountTo] = useState(25);
  const [count, setCount] = useState(0);

  const submit = async () => {
    console.log("Submitting", countTo);
    
    const res = client.countTo({
      to: countTo
    })

    for await (const response of res) {
      setCount(response.count);
    }
  }

  return <Layout title="Home | Next.js + TypeScript Example">
    <input value={countTo} onChange={(e) => setCountTo(parseInt(e.target.value))} />
    <button onClick={submit}>Go!</button><br/>
  
    Current value: {count}
  </Layout>
}
```

I have created a repo here: https://github.com/dylanratcliffe/server-streaming-test that sends a request to a server and then listens for many responses. I think that this could be a good to use going forward for making the whole app extremely responsive.