### PR TITLE
Remove now unused attributes

### DIFF
--- a/items.proto
+++ b/items.proto
@@ -191,20 +191,6 @@ message Query {
   // query including all linking needs to be done in 10s, not 10s for *each*
   // query
   google.protobuf.Duration timeout = 8;
-
-  // The below fields are used when a query is made over the NATS network and
-  // the requester needs to specify where the results of that query should be
-  // sent. These subjects will be used in addition to the defaults and are
-  // usually just dynamically generated inboxes
-
-  // Subject that items resulting from the query should be sent to
-  string itemSubject = 16;
-
-  // Subject that both interim and final responses should be sent to
-  string responseSubject = 17;
-
-  // Subject that errors will be sent to
-  string errorSubject = 18;
 }
 
 message QueryResponse {


### PR DESCRIPTION
This is a separate commit to avoid breaking everything before the migration PRs have landed, except that current SDP `main` is already breaking dependencies because of #81, so no need to hold back

ref #79