### PR TITLE
Added tags to items

### DIFF
--- a/items.proto
+++ b/items.proto
@@ -91,6 +91,11 @@ message Item {
   // (optional) Represents the health of the item. Only items that have a
   // clearly relevant health attribute should return a value for health
   optional Health health = 18;
+
+  // Arbitrary key-value pairs that can be used to store additional information.
+  // These tags are retrieved from the source and map to the target's definition
+  // of a tag (e.g. AWS tags, Kubernetes labels, etc.)
+  map<string, string> tags = 19;
 }
 
 // ItemAttributes represents the known attributes for an item. These are likely


### PR DESCRIPTION
See #132 for details.

This PR adds tags a a new field on items, allowing us to nice grouping in future with "explore". In golang this becomes:

```go
// Arbitrary key-value pairs that can be used to store additional information.
// These tags are retrieved from the source and map to the target's definition
// of a tag (e.g. AWS tags, Kubernetes labels, etc.)
Tags map[string]string `protobuf:"bytes,19,rep,name=tags,proto3" json:"tags,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
```

And in typescript:

```ts
export class Item extends Message<Item> {
  tags: { [key: string]: string } = {};
}
```