### PR TITLE
feat: add risks to ChangeSummary

### DIFF
--- a/changes.proto
+++ b/changes.proto
@@ -521,11 +521,14 @@ message ChangeSummary {
   // The number of edges in the blast radius of this change
   int32 numAffectedEdges = 10;
   
-  // Risk status to show in changes list
-  RiskCalculationStatus riskCalculationStatus = 11;
+  // The number of low risks in this change
+  int32 numLowRisk = 11;
 
-  // The Risks associated with change
-  repeated Risk risks = 12;
+  // The number of medium risks in this change
+  int32 numMediumRisk = 12;
+
+  // The number of high risks in this change
+  int32 numHighRisk = 13;
 }
 
 // a complete Change with machine-supplied and user-supplied values
@@ -604,8 +607,18 @@ message ChangeMetadata {
   HealthChange WarningHealthChange = 14;
   HealthChange ErrorHealthChange = 15;
   HealthChange PendingHealthChange = 16;
+
   RiskCalculationStatus riskCalculationStatus = 19;
   repeated Risk risks = 20;
+
+  // The number of low risks in this change
+  int32 numLowRisk = 21;
+
+  // The number of medium risks in this change
+  int32 numMediumRisk = 22;
+
+  // The number of high risks in this change
+  int32 numHighRisk = 23;
 }
 
 // user-supplied properties of this change

--- a/changes.proto
+++ b/changes.proto
@@ -520,6 +520,12 @@ message ChangeSummary {
 
   // The number of edges in the blast radius of this change
   int32 numAffectedEdges = 10;
+  
+  // Risk status to show in changes list
+  RiskCalculationStatus RiskCalculationStatus = 11;
+
+  // The Risks associated with change
+  repeated Risk risks = 12;
 }
 
 // a complete Change with machine-supplied and user-supplied values

--- a/changes.proto
+++ b/changes.proto
@@ -522,7 +522,7 @@ message ChangeSummary {
   int32 numAffectedEdges = 10;
   
   // Risk status to show in changes list
-  RiskCalculationStatus RiskCalculationStatus = 11;
+  RiskCalculationStatus riskCalculationStatus = 11;
 
   // The Risks associated with change
   repeated Risk risks = 12;
@@ -604,7 +604,7 @@ message ChangeMetadata {
   HealthChange WarningHealthChange = 14;
   HealthChange ErrorHealthChange = 15;
   HealthChange PendingHealthChange = 16;
-  RiskCalculationStatus RiskCalculationStatus = 19;
+  RiskCalculationStatus riskCalculationStatus = 19;
   repeated Risk risks = 20;
 }
 


### PR DESCRIPTION
Currently the `/changes` page data is populated by `ChangesSummary` and not `Changes`. This PR adds the risks to summary so that the UI can reflect the new designs.