### PR TITLE
Add unexpectedUnchangedItems to GetDiffResponse, clarify docs

### DIFF
--- a/changes.proto
+++ b/changes.proto
@@ -178,15 +178,16 @@ message GetDiffRequest {
 }
 
 message GetDiffResponse {
-  // Changes to items that were used to calculate the blast radius, i.e. items
-  // we expected to change
+  // Items that were planned to be changed, and were changed
   repeated ItemDiff expectedItems = 1;
 
-  // Items that changed within the blast radius, but that weren't used to
-  // calculate it i.e. unexpected changes
+  // Items that were changed, but were not planned to be changed
   repeated ItemDiff unexpectedItems = 3;
 
   repeated Edge edges = 2;
+
+  // Items that were planned to be changed, but were not changed
+  repeated ItemDiff unexpectedUnchangedItems = 4;
 }
 
 message ListChangingItemsSummaryRequest {


### PR DESCRIPTION
* unexpected: items that were not planned to change but changed
* expected: items that were planned to change and did change
* unexpectedUnchanged: items that were planned to change but did not change (these will be called "missing" in the UI, to use a simpler term when there is more context so it does not mislead)