### PR TITLE
Revert "Merge pull request #171 from overmindtech/is-system"

### DIFF
--- a/gateway.proto
+++ b/gateway.proto
@@ -175,10 +175,6 @@ message StoreSnapshot {
     string description = 2;
     // a correlation ID to match up requests and responses. set this to a value unique per connection
     bytes msgID = 3;
-    // whether this snapshot should be stored as a system snapshot. System
-    // snapshots are hidden and can only be returned via the UUID, they don't
-    // show up in lists
-    bool isSystem = 4;
 }
 
 // After a snapshot is successfully stored, this reply with the new snapshot's details is sent.
@@ -192,9 +188,6 @@ message SnapshotStoreResult {
     // a correlation ID to match up requests and responses. this field returns the contents of the request's msgID
     bytes msgID = 4;
     bytes snapshotID = 5; // The UUID of the newly stored snapshot
-    // System snapshots are hidden and can only be returned via the UUID, they
-    // don't show up in lists
-    bool isSystem = 6;
 }
 
 // Ask the gateway to load the specified snapshot into the current state.


### PR DESCRIPTION
This reverts commit f7389ef9d5b1a709ffbe6041820641ef5559da23, reversing changes made to c832e6f70235b64e89b9b31eb837f43f68e69c40.

Turns out CreateBookmark already has `isSystem`. @getinnocuous you should use that instead of create snapshot