### PR TITLE
add customer id to account

### DIFF
--- a/account.proto
+++ b/account.proto
@@ -208,6 +208,8 @@ message AccountMetadata {
 message AccountProperties {
     // The name of the account
     string Name = 1;
+    // The Customer ID within Stripe
+    string CustomerID = 2;
 }
 
 message GetAccountRequest {}

--- a/account.proto
+++ b/account.proto
@@ -209,7 +209,7 @@ message AccountProperties {
     // The name of the account
     string Name = 1;
     // The Customer ID within Stripe
-    string CustomerID = 2;
+    string StripeCustomerID = 2;
 }
 
 message GetAccountRequest {}


### PR DESCRIPTION
Adding the Stripe Customer ID, this value needs to be stored so we can perform lookups in Stripe based on the Overmind user.

**This isn't implemented in the backend yet though.**
