### PR TITLE
Added frontend redirect URL

### DIFF
--- a/apikeys.proto
+++ b/apikeys.proto
@@ -148,6 +148,11 @@ message CreateAPIKeyResponse {
 message RefreshAPIKeyRequest {
     // The UUID of the API key to refresh
     bytes uuid = 1;
+
+    // The URL that the user should be redirected to after the whole process is
+    // over. This should be a page in the frontend, probably the one they
+    // started from, but could also be a detail page for this particular API key
+    string finalFrontendRedirect = 2;
 }
 
 message RefreshAPIKeyResponse {


### PR DESCRIPTION
We need this so that we know where to send people after they have refreshed the key. This will be same as is it for regular API keys, but better to have it here so that it's flexible if we ever wanted to move which page the button was on for example