### PR TITLE
Added more granularity to responses

### DIFF
--- a/account.proto
+++ b/account.proto
@@ -297,6 +297,19 @@ message KeepaliveSourcesRequest {
     bool waitForHealthy = 1;
 }
 message KeepaliveSourcesResponse {
+    message SourceKeepaliveResult {
+        // The UUID of the source that was kept alive
+        bytes UUID = 1;
+        // The status of the source
+        SourceStatus Status = 2;
+        // The error message if the source is unhealthy
+        string Error = 3;
+    }
+
+    // If the user requested to wait for the sources to be healthy, this will
+    // contain information about the sources that came up. If the user did not
+    // request to wait, this will be empty
+    repeated SourceKeepaliveResult sources = 1;
 }
 
 message CreateTokenRequest {

--- a/account.proto
+++ b/account.proto
@@ -292,20 +292,20 @@ message DeleteSourceRequest {
 
 message DeleteSourceResponse {}
 
+message SourceKeepaliveResult {
+    // The UUID of the source that was kept alive
+    bytes UUID = 1;
+    // The status of the source
+    SourceStatus Status = 2;
+    // The error message if the source is unhealthy
+    string Error = 3;
+}
+
 message KeepaliveSourcesRequest {
     // Set to true to have the API call wait until the source is up and healthy
     bool waitForHealthy = 1;
 }
 message KeepaliveSourcesResponse {
-    message SourceKeepaliveResult {
-        // The UUID of the source that was kept alive
-        bytes UUID = 1;
-        // The status of the source
-        SourceStatus Status = 2;
-        // The error message if the source is unhealthy
-        string Error = 3;
-    }
-
     // If the user requested to wait for the sources to be healthy, this will
     // contain information about the sources that came up. If the user did not
     // request to wait, this will be empty


### PR DESCRIPTION
RE: https://github.com/overmindtech/gateway/issues/671

This gives us details of what sources started and what didn't. This means that the gateway can make an intelligent decision like "If some of them worked then we're okay"