### PR TITLE
feat: remove status

### DIFF
--- a/changes.proto
+++ b/changes.proto
@@ -290,7 +290,6 @@ message PopulateChangeFiltersRequest {}
 message PopulateChangeFiltersResponse {
   repeated string repos = 1;
   repeated string authors = 2;
-  repeated ChangeStatus statuses = 3;
 }
 
 message ListHomeAppsRequest {}


### PR DESCRIPTION
Status is an ENUM so we don't need to query it, we can just populate the fields on the frontend.