### PR TITLE
feat: add tags to ChangeSummary

### DIFF
--- a/changes.proto
+++ b/changes.proto
@@ -577,6 +577,9 @@ message ChangeSummary {
 
   // Repo information; can be an empty string. CLI attempts auto-population, but users can override. Not necessarily a URL. The UI will be responsible for any formatting/shortnening/sprucing up should it be required.
   string repo = 16;
+
+  // User-defined tags associated with this change, will be populated via the CLI and not the UI.
+  map<string, string> tags = 17;
 }
 
 // a complete Change with machine-supplied and user-supplied values


### PR DESCRIPTION
This is the type that is listed on the changes page. It will need to be added to the response in order to populate the tag data in the change cards UI component.