### PR TITLE
Clarify valid values

### DIFF
--- a/changes.proto
+++ b/changes.proto
@@ -211,9 +211,16 @@ message RuleProperties {
   // be applied and what its value should be
   string instructions = 4;
 
-  // A list of valid tag values. If the instructions produce a value that is not
-  // in this list, the rule will be retried, however if we cannot converge on a
-  // valid value after some number of tries, the rule will not be applied
+  // A list of valid tag values.
+  //
+  // If this list is empty then the tag will have no value. Overmind will
+  // evaluate the instructions in the context of each incoming change, and if
+  // instructed, it will tag that change with the given `tagKey` and an empty
+  // value.
+  //
+  // If this list is populated, Overmind will evaluate the instructions in the
+  // context of each incoming change and decide; whether to tag the change at
+  // all, and if so, what value to use.
   repeated string validValues = 5;
 }
 
@@ -646,7 +653,7 @@ message TagValue {
 }
 
 message UserTagValue {
-  // The value of the tag that was set by the user
+  // The value of the tag that was set by the user.
   string value = 1;
 }
 


### PR DESCRIPTION
Clarify how the `validValues` array should be treated when evaluating a change